### PR TITLE
chore(tests): fix deprecation warning in pytest-asyncio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 -
 # and install only runtime deps using poetry
 WORKDIR $PYSETUP_PATH
 COPY ./poetry.lock ./pyproject.toml ./
-RUN poetry install --no-dev  # respects 
+RUN poetry install --no-dev
 
 # 'production' stage uses the clean 'python-base' stage and copyies
 # in only our runtime deps that were installed in the 'builder-base'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,8 @@ build-backend = "poetry.core.masonry.api"
 # https://www.python.org/dev/peps/pep-0518/
 [tool.isort]
 profile = "black"
+
+# Fix deprecation warning
+# https://github.com/pytest-dev/pytest-asyncio/blob/d8efa640f0aa1ba8856b908ba486150588018209/pytest_asyncio/plugin.py#L61
+[tool.pytest.ini_options]
+asyncio_mode = "auto"


### PR DESCRIPTION
Triggered by https://github.com/pytest-dev/pytest-asyncio/blob/d8efa640f0aa1ba8856b908ba486150588018209/pytest_asyncio/plugin.py#L61
Thanks to https://github.com/layday/instawow/blob/main/pyproject.toml
for a concrete example to configure pyproject.tom