### PR TITLE
feat: add spotify app link

### DIFF
--- a/tests/test_spotify_api.py
+++ b/tests/test_spotify_api.py
@@ -8,6 +8,7 @@ from whats_on_fip.models import Track
 from whats_on_fip.spotify_api import (
     SpotifyTrackNotFound,
     add_spotify_external_url,
+    get_spotify_app_link,
     get_spotify_track,
     search_on_spotify,
 )
@@ -19,7 +20,8 @@ simple_queries_responses = {
         "artist": "Supertramp",
         "title": "The Logical Song - Remastered 2010",
         "external_urls": {
-            "spotify": "https://open.spotify.com/track/6mHOcVtsHLMuesJkswc0GZ"
+            "spotify": "https://open.spotify.com/track/6mHOcVtsHLMuesJkswc0GZ",
+            "spotify_app": "spotify:track:6mHOcVtsHLMuesJkswc0GZ",
         },
     },
     'album:"logical song" year:1979': {
@@ -28,7 +30,8 @@ simple_queries_responses = {
         "artist": "Supertramp",
         "title": "The Logical Song",
         "external_urls": {
-            "spotify": "https://open.spotify.com/track/4se2fj5uRWlkcnfhtnRLrZ"
+            "spotify": "https://open.spotify.com/track/4se2fj5uRWlkcnfhtnRLrZ",
+            "spotify_app": "spotify:track:4se2fj5uRWlkcnfhtnRLrZ",
         },
     },
 }
@@ -109,6 +112,14 @@ def test_get_spotify_track_unknown(mocker):
         get_spotify_track(input_track)
 
 
+def test_get_spotify_app_link():
+    for t in simple_queries_responses.values():
+        if "spotify" in t["external_urls"]:
+            assert t["external_urls"]["spotify_app"] == get_spotify_app_link(
+                t["external_urls"]["spotify"]
+            )
+
+
 def test_add_spotify_external_url(mocker):
     mocker.patch(
         "requests.get",
@@ -156,12 +167,12 @@ def test_add_spotify_external_url_already_existing(mocker):
         title="logical song",
         album="Breakfeast in America",
         artist="supertramp",
-        external_urls={"spotify": "A random link already there"},
+        external_urls={"spotify": "https://open.spotify.com/track/random-valid-id"},
     )
 
     output_track = input_track.copy(deep=True)
-    output_track.external_urls = simple_queries_responses["logical song supertramp"][
-        "external_urls"
-    ]
+    output_track.external_urls["spotify_app"] = get_spotify_app_link(
+        input_track.external_urls["spotify"]
+    )
 
     assert add_spotify_external_url(input_track) == output_track

--- a/whats_on_fip/main.py
+++ b/whats_on_fip/main.py
@@ -78,9 +78,7 @@ async def get_live(
 
     # Add spotify external_url if necessary
     try:
-        if not ("spotify" in track.external_urls):
-            logger.info("Looking for the track on spotify")
-            track = add_spotify_external_url(track)
+        track = add_spotify_external_url(track)
     except Exception as e:
         logger.warning("Error while using spotify API: " + str(e))
 
@@ -112,9 +110,7 @@ async def get_live_meuh() -> Track:
     track = get_current_meuh()
     # Add spotify external_url if necessary
     try:
-        if not ("spotify" in track.external_urls):
-            logger.info("Looking for the track on spotify")
-            track = add_spotify_external_url(track)
+        track = add_spotify_external_url(track)
     except Exception as e:
         logger.warning("Error while using spotify API: " + str(e))
 

--- a/whats_on_fip/models.py
+++ b/whats_on_fip/models.py
@@ -13,6 +13,9 @@ class Track(BaseModel):
     external_urls: Dict[str, str] = {}
     cover_url: Optional[str]
 
+    def __str__(self) -> str:
+        return self.title + f" ({self.year})" if self.year else "" + f" - {self.artist}"
+
 
 class Station(BaseModel):
     name: str

--- a/whats_on_fip/spotify_api.py
+++ b/whats_on_fip/spotify_api.py
@@ -44,17 +44,28 @@ def get_spotify_track(input_track: Track) -> Track:
     return spotifyTrack
 
 
-def add_spotify_external_url(input_track: Track) -> Track:
-    external_urls = input_track.external_urls
-    try:
-        spotifyTrack = get_spotify_track(input_track)
-        if "spotify" in spotifyTrack.external_urls:
-            logger.info("Adding a spotify url to track")
-            external_urls["spotify"] = spotifyTrack.external_urls["spotify"]
-    except SpotifyTrackNotFound:
-        # already logged previously
-        pass
+def get_spotify_app_link(spotify_url: str) -> str:
+    track_id = spotify_url.split("/")[-1]
+    return f"spotify:track:{track_id}"
 
+
+def add_spotify_external_url(input_track: Track) -> Track:
+    logger.info(f"Looking for track {input_track} on spotify")
     output_track = input_track.copy(deep=True)
-    output_track.external_urls = external_urls
+    if "spotify" not in output_track.external_urls:
+        try:
+            spotifyTrack = get_spotify_track(input_track)
+            if "spotify" in spotifyTrack.external_urls:
+                logger.info("Adding a spotify url to track")
+                output_track.external_urls["spotify"] = spotifyTrack.external_urls[
+                    "spotify"
+                ]
+        except SpotifyTrackNotFound:
+            logger.warning(f"no spotify URL found for track {input_track}")
+
+    if "spotify" in output_track.external_urls:
+        output_track.external_urls["spotify_app"] = get_spotify_app_link(
+            output_track.external_urls["spotify"]
+        )
+
     return output_track


### PR DESCRIPTION
Add a link in the format spotify:track:<track-id> in the response

Can be useful for Slack link to redirect to app instead of web Spotify
version

Fixes #64